### PR TITLE
Enforce interoperable behavior for unsupported 'type' assertion values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -273,7 +273,7 @@
     <emu-grammar>AssertClause : `assert` `{` AssertEntries `,`? `}`</emu-grammar>
     <ul>
       <li>It is a Syntax Error if AssertClauseToAssertions of |AssertClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
-      <li>It is a Syntax Error if AssertClauseToAssertions of |AssertClause| has an entry _a_ such that _a_.[[Key]] is *"type"* and _a_.[[Value]] is not an entry of !HostGetSupportedExtraModuleScriptTypes().</li>
+      <li>It is a Syntax Error if AssertClauseToAssertions of |AssertClause| has an entry _a_ such that _a_.[[Key]] is *"type"* and ! HostGetSupportedExtraModuleScriptTypes() does not contain _a_.[[Value]].</li>
     </ul>
   </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -101,6 +101,9 @@
               1. <ins>If Type(_value_) is not String, then</ins>
                 1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
                 1. <ins>Return _promiseCapability_.[[Promise]].</ins>
+              1. <ins>If _key_ is *"type"* and _value_ is not an entry of !HostGetSupportedExtraModuleScriptTypes(), then</ins>
+                1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
+                1. <ins>Return _promiseCapability_.[[Promise]].</ins>
               1. <ins>If _key_ is an entry of _supportedAssertions_, append { [[Key]]: _key_, [[Value]]: _value_ } to _assertions_.</ins>
             1. <ins>Sort _assertions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.</ens>
           1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Assertions]]: _assertions_ }.</ins>
@@ -241,11 +244,36 @@
     <emu-note type=editor>The purpose of requiring the host to specify its supported import assertions, rather than passing all assertions to the host and letting it then choose which ones it wants to handle, is to ensure that unsupported assertions are handled in a consistent way across different hosts.</emu-note>
   </emu-clause>
 
+  <emu-clause id="sec-hostgetsupportedextramodulescripttypes" aoid="HostGetSupportedExtraModuleScriptTypes">
+    <h1>Static Semantics: HostGetSupportedExtraModuleScriptTypes ()</h1>
+    <p>
+      HostGetSupportedExtraModuleScriptTypes is a host-defined abstract operation that allows host environments to specify which types of module scripts they support in addition to Source Text Module Record.
+      Module script type assertions with unsupported values will cause an error.
+    </p>
+
+    <p>The implementation of HostGetSupportedExtraModuleScriptTypes must conform to the following requrements:</p>
+
+    <ul>
+      <li>It must return a List whose values are all StringValues, each indicating a supported module script type.</li>
+
+      <li>None of the string values may be *"js"* or *"javascript"*.<emu-note type="editor">It is assumed that Source Text Module Record must be supported.</emu-note></li>
+
+      <li>Each time this operation is called, it must return the same List instance with the same contents.</li>
+
+      <li>An implementation of HostGetSupportedExtraModuleScriptTypes must always complete normally (i.e., not return an abrupt completion).</li>
+    </ul>
+
+    <p>The default implementation of HostGetSupportedExtraModuleScriptTypes is to return an empty List.</p>
+
+    <emu-note type="editor">The purpose of requiring the host to specify its supported module types, rather than passing all type assertion values to the host and letting it then choose which ones it wants to handle, is to ensure that unsupported module types are handled in a consistent way across different hosts.</emu-note>
+  </emu-clause>
+
   <emu-clause id="sec-assert-clause-early-errors">
     <h1>Static Semantics: Early Errors</h1>
     <emu-grammar>AssertClause : `assert` `{` AssertEntries `,`? `}`</emu-grammar>
     <ul>
       <li>It is a Syntax Error if AssertClauseToAssertions of |AssertClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
+      <li>It is a Syntax Error if AssertClauseToAssertions of |AssertClause| has an entry _a_ such that _a_.[[Key]] is *"type"* and _a_.[[Value]] is not an entry of !HostGetSupportedExtraModuleScriptTypes().</li>
     </ul>
   </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -101,7 +101,7 @@
               1. <ins>If Type(_value_) is not String, then</ins>
                 1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
                 1. <ins>Return _promiseCapability_.[[Promise]].</ins>
-              1. <ins>If _key_ is *"type"* and _value_ is not an entry of !HostGetSupportedExtraModuleScriptTypes(), then</ins>
+              1. <ins>If _key_ is *"type"* and ! HostGetSupportedExtraModuleScriptTypes() does not contain _value_, then</ins>
                 1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
                 1. <ins>Return _promiseCapability_.[[Promise]].</ins>
               1. <ins>If _key_ is an entry of _supportedAssertions_, append { [[Key]]: _key_, [[Value]]: _value_ } to _assertions_.</ins>

--- a/spec.html
+++ b/spec.html
@@ -256,8 +256,6 @@
     <ul>
       <li>It must return a List whose values are all StringValues, each indicating a supported module script type.</li>
 
-      <li>None of the string values may be *"js"* or *"javascript"*.<emu-note type="editor">It is assumed that Source Text Module Record must be supported.</emu-note></li>
-
       <li>Each time this operation is called, it must return the same List instance with the same contents.</li>
 
       <li>An implementation of HostGetSupportedExtraModuleScriptTypes must always complete normally (i.e., not return an abrupt completion).</li>
@@ -265,7 +263,10 @@
 
     <p>The default implementation of HostGetSupportedExtraModuleScriptTypes is to return an empty List.</p>
 
-    <emu-note type="editor">The purpose of requiring the host to specify its supported module types, rather than passing all type assertion values to the host and letting it then choose which ones it wants to handle, is to ensure that unsupported module types are handled in a consistent way across different hosts.</emu-note>
+    <emu-note type="editor">
+      <p>The purpose of requiring the host to specify its supported module types, rather than passing all type assertion values to the host and letting it then choose which ones it wants to handle, is to ensure that unsupported module types are handled in a consistent way across different hosts.</p>
+      <p>It is assumed that Source Text Module Record must be supported, so hosts do not need to provide a value for these in the list.</p>
+    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-assert-clause-early-errors">


### PR DESCRIPTION
In https://github.com/tc39/proposal-import-assertions/issues/27 there was discussion about what to do with unrecognized types.  If we want to enforce that unsupported 'type' assertion values always trigger a failure, this is one way to do it.

This change enforces that unsupported values of the 'type' assertion will trigger a failure.  This is done with the introduction of the  host-defined operation HostGetSupportedExtraModuleScriptTypes.  Hosts will use this operation to indicate which module types (other than JavaScript) they support. If an import statement includes a type assertion that the host does not support, it will result in a syntax error (or TypeError with dynamic import()).

The result is unsupported types will be treated the same on all hosts, rather than some hosts ignoring them and some hosts triggering failure.

This change is written to avoid the scenario where a host could decide whether or not either of the following are supported:
```js
import "./foo.js" assert { type: "js" };
import "./foo.js" assert { type: "javascript" };
```

In https://github.com/tc39/proposal-import-assertions/issues/49 we discussed whether these should be permitted.  They are current not permitted, but if we decide to allow them in the future then that decision should be made within EcmaScript rather than by hosts. This is enforced by the requirement that these values are not present in the host's implementation of HostGetSupportedExtraModuleScriptTypes.

Alternatively we could name the HostGetSupportedModuleScriptTypes and require the host to state whether it supports JavaScript modules. But what would it mean for a host *not* to support JavaScript modules, if it contains module imports? We avoid the question altogether If we use HostGetSupportedExtraModuleScriptTypes and only require hosts to specify module types other than JavaScript.